### PR TITLE
lancelot: crop screen grabs if full-screen (eglfs)

### DIFF
--- a/lancelot_templates/scenegrabber/main.cpp
+++ b/lancelot_templates/scenegrabber/main.cpp
@@ -111,6 +111,9 @@ private slots:
 #ifdef GRABBERDEBUG
         printf("...sceneStabilized IN\n");
 #endif
+        if (QGuiApplication::platformName() == QLatin1String("eglfs"))
+            lastGrab = lastGrab.copy(QRect(QPoint(0, 0), initialSize()));
+
         if (ofile == "-") {   // Write to stdout
             QFile of;
 #ifdef Q_OS_WIN


### PR DESCRIPTION
Under eglfs, grabWindow() will return the entire screen. Crop it to
the interesting, actually rendered part.