### PR TITLE
Fix up settings for some scenes, add xPos setting

### DIFF
--- a/generate-quick3d-project.py
+++ b/generate-quick3d-project.py
@@ -191,10 +191,12 @@ def generate_lancelot_tests(output_dir, tests):
 
         scale = 1
         yPos = 0
+        xPos = 0
         isAnimated = False
         if test in settings:
             scale = settings[test]['scale']
-            yPos = settings[test]['y']
+            xPos = settings[test].get('x', 0)
+            yPos = settings[test].get('y', 0)
             isAnimated = settings[test]['animated']
 
         if isAnimated:
@@ -217,8 +219,9 @@ def generate_lancelot_tests(output_dir, tests):
         # scale (settings file)
         localTemplate = localTemplate.replace("@@@", "Qt.vector3d(" + str(scale) + ", " + str(scale) + ", " + str(scale) + ")")
 
-        # y position (settings file)
-        localTemplate = localTemplate.replace("$$$", str(yPos))
+        # x,y position (settings file)
+        localTemplate = localTemplate.replace("$x$", str(xPos))
+        localTemplate = localTemplate.replace("$y$", str(yPos))
 
         # write test file
         componentName = componentName.replace(".qml", "")

--- a/lancelot_settings.json
+++ b/lancelot_settings.json
@@ -74,6 +74,11 @@
         "y": 0,
         "animated": false
     },
+    "Box_With_Spaces": {
+        "scale": 100,
+        "y": 0,
+        "animated": false
+    },
     "BoxTexturedNonPowerOfTwo": {
         "scale": 300,
         "y": 0,
@@ -85,8 +90,8 @@
         "animated": false
     },
     "BrainStem": {
-        "scale": 17,
-        "y": -17,
+        "scale": 280,
+        "y": -280,
         "animated": true
     },
     "Buggy": {
@@ -100,8 +105,8 @@
         "animated": false
     },
     "CesiumMan": {
-        "scale": 17,
-        "y": 0,
+        "scale": 300,
+        "y": -300,
         "animated": true
     },
     "CesiumMilkTruck": {
@@ -145,8 +150,8 @@
         "animated": false
     },
     "Fox": {
-        "scale": 2,
-        "y": -50,
+        "scale": 5,
+        "y": -250,
         "animated": true
     },
     "GearboxAssy": {
@@ -167,6 +172,11 @@
     "MetalRoughSpheres": {
         "scale": 70,
         "y": 10,
+        "animated": false
+    },
+    "MaterialsVariantsShoe": {
+        "scale": 2000,
+        "y": -200,
         "animated": false
     },
     "MetalRoughSpheresNoTextures": {
@@ -205,18 +215,28 @@
         "animated": false
     },
     "RiggedFigure": {
-        "scale": 30,
-        "y": 0,
+        "scale": 300,
+        "y": -300,
         "animated": true
     },
     "RiggedSimple": {
-        "scale": 8,
-        "y": 0,
+        "scale": 50,
+        "y": -50,
         "animated": true
     },
     "SciFiHelmet": {
         "scale": 200,
         "y": 0,
+        "animated": false
+    },
+    "SheenChair": {
+        "scale": 500,
+        "y": -250,
+        "animated": false
+    },
+    "SheenCloth": {
+        "scale": 10000,
+        "y": -200,
         "animated": false
     },
     "SimpleMeshes": {
@@ -230,8 +250,8 @@
         "animated": true
     },
     "SimpleSkin": {
-        "scale": 100,
-        "y": 0,
+        "scale": 200,
+        "y": -200,
         "animated": true
     },
     "SimpleSparseAccessor": {
@@ -242,6 +262,11 @@
     "SpecGlossVsMetalRough": {
         "scale": 1800,
         "y": 0,
+        "animated": false
+    },
+    "SpecularTest": {
+        "scale": 800,
+        "x": 145,
         "animated": false
     },
     "Sponza": {
@@ -259,6 +284,16 @@
         "y": 0,
         "animated": false
     },
+    "TextureEncodingTest": {
+        "scale": 60,
+        "y": 0,
+        "animated": false
+    },
+    "TextureLinearInterpolationTest": {
+        "scale": 100,
+        "y": -50,
+        "animated": false
+    },
     "TextureSettingsTest": {
         "scale": 60,
         "y": 50,
@@ -274,9 +309,14 @@
         "y": 0,
         "animated": false
     },
+    "TransmissionRoughnessTest": {
+        "scale": 600,
+        "x": 30,
+        "animated": false
+    },
     "TransmissionTest": {
-        "scale": 550,
-        "y": 50,
+        "scale": 600,
+        "x": 60,
         "animated": false
     },
     "Triangle": {

--- a/templates/LancelotView.qml
+++ b/templates/LancelotView.qml
@@ -3,11 +3,11 @@ import QtQuick3D
 
 Rectangle {
     id: window
-	width: 640
-	height: 480
+    width: 640
+    height: 480
     color: "black"
 
-	Node {
+    Node {
         id: sceneRoot
 
         PerspectiveCamera {
@@ -19,14 +19,15 @@ Rectangle {
             id: loadedItem
             source: ###
             scale: @@@
-            y: $$$
+            x: $x$
+            y: $y$
         }
     }
 
     View3D {
         anchors.fill: parent
         importScene: sceneRoot
-		environment: SceneEnvironment {
+        environment: SceneEnvironment {
             lightProbe: Texture {
                 source: "../environment.hdr"
             }


### PR DESCRIPTION
After a recent fix to mesh skinning, the scaling of some scenes were
completely off. Also, some other scenes lacked settings and needed
them to produce visible rendering. Also added option to specify x
position in addition to the y position, to be able to tune the
rendered screenshot better.