### PR TITLE
Checksum all source files to avoid false mismatches

### DIFF
--- a/lancelot_templates/shared/qbaselinetest.pri
+++ b/lancelot_templates/shared/qbaselinetest.pri
@@ -6,9 +6,4 @@ SOURCES += \
 HEADERS += \
         $$PWD/qbaselinetest.h
 
-qtHaveModule(widgets) {
-        SOURCES += $$PWD/qwidgetbaselinetest.cpp
-        HEADERS += $$PWD/qwidgetbaselinetest.h
-}
-
 include($$PWD/baselineprotocol.pri)


### PR DESCRIPTION
To avoid comparing apples to oranges when a test item itself has been changed, the lancelot system uses a checksum of the item's input files. However, the implementation here would cheksum only the main qml file, and not the maps and meshes etc. Fix by recursively checksum the entire item directory.