### PR TITLE
Sort glTF variant directories for consistent platform behavior

### DIFF
--- a/generate-quick3d-project.py
+++ b/generate-quick3d-project.py
@@ -114,7 +114,7 @@ def generate_tests(directory, blacklist):
             continue
         os.chdir(model)
         model_contents = os.listdir(".")
-        gltf_variant_dirs = [d for d in model_contents if d.startswith("glTF")]
+        gltf_variant_dirs = sorted(d for d in model_contents if d.startswith("glTF"))
 
         for variant_dir in gltf_variant_dirs:
             # assimp v5.2.5 cannot support buffer descriptions


### PR DESCRIPTION
os.listdir() returns entries in filesystem order, which is hash-based on Linux (ext4) and alphabetical on macOS/Windows. For models like FlightHelmet and StainedGlassLamp that have both glTF and glTF-KTX-BasisU variants, Linux would non-deterministically pick the KTX variant first. Balsam silently drops KTX2 textures, resulting in texture-less materials and a flat grey render on Linux only.

Sorting ensures glTF always takes priority over glTF-KTX-BasisU across all platforms.